### PR TITLE
ros2: fix compiling with ROS2 foxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,54 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(auv_msgs)
 
-find_package(catkin REQUIRED COMPONENTS
-  std_msgs
-  sensor_msgs
-  geometry_msgs
-  geographic_msgs
-  message_generation
-)
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
 
-add_message_files(
-  DIRECTORY
-    msg
-  FILES
-    BodyForceRequest.msg
-    BodyVelocityRequest.msg
-    NavigationStatus.msg
-    NED.msg
-    NEDArray.msg
-    VehiclePose.msg
-    VehiclePoseArray.msg
-    WorldWaypointRequest.msg
-)
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-generate_messages(
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(geographic_msgs REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+    msg/BodyForceRequest.msg
+    msg/BodyVelocityRequest.msg
+    msg/NavigationStatus.msg
+    msg/NED.msg
+    msg/NEDArray.msg
+    msg/VehiclePose.msg
+    msg/VehiclePoseArray.msg
+    msg/WorldWaypointRequest.msg
   DEPENDENCIES
-  std_msgs
-  sensor_msgs
-  geometry_msgs
-  geographic_msgs
-)
-
-catkin_package(
-  CATKIN_DEPENDS
-    geographic_msgs
-    geometry_msgs
     std_msgs
     sensor_msgs
-    message_runtime
+    geometry_msgs
+    geographic_msgs
 )
+
+ament_package()

--- a/msg/BodyForceRequest.msg
+++ b/msg/BodyForceRequest.msg
@@ -4,7 +4,7 @@
 # to simplify integration with arm control systems.
 
 # header.frame_id should be set to the base_link frame of the vehicle.
-Header header
+std_msgs/Header header
 
 geometry_msgs/Wrench wrench
 

--- a/msg/BodyVelocityRequest.msg
+++ b/msg/BodyVelocityRequest.msg
@@ -4,7 +4,7 @@
 # to simplify integration with arm control systems.
 
 # header.frame_id should be set to the base_link frame of the vehicle.
-Header header
+std_msgs/Header header
 
 geometry_msgs/Twist twist
 

--- a/msg/NavigationStatus.msg
+++ b/msg/NavigationStatus.msg
@@ -1,6 +1,6 @@
 # Sent by the navigator at 5-10 Hz.
 
-Header 	header
+std_msgs/Header 	header
 
 geographic_msgs/GeoPoint global_position
 geographic_msgs/GeoPoint origin

--- a/msg/VehiclePoseArray.msg
+++ b/msg/VehiclePoseArray.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 VehiclePose[] poses

--- a/msg/WorldWaypointRequest.msg
+++ b/msg/WorldWaypointRequest.msg
@@ -1,6 +1,6 @@
 # World frame (absolute) waypoint request to pilot.
 
-Header header
+std_msgs/Header header
 
 # Waypoint request
 auv_msgs/NED position

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,6 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>auv_msgs</name>
   <version>0.1.0</version>
   <description>This package provides message types commonly used with Autonomous Underwater Vehicles</description>
@@ -7,12 +9,22 @@
   <author>Ocean Systems Lab, Heriot-Watt University</author>
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>std_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>geographic_msgs</depend>
-  <build_depend>message_generation</build_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>geographic_msgs</build_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>


### PR DESCRIPTION
This fixes the package so the messages will generate on ROS2 Foxy. This closes #5 .